### PR TITLE
Bring over readable collection definition from memex ext

### DIFF
--- a/ts/mobile-app/features/meta-picker/storage/index.ts
+++ b/ts/mobile-app/features/meta-picker/storage/index.ts
@@ -3,7 +3,7 @@ import {
     StorageModuleConfig,
     StorageModuleConstructorArgs,
 } from '@worldbrain/storex-pattern-modules'
-import { URLNormalizer } from '@worldbrain/memex-url-utils/lib/normalize/types'
+import { URLNormalizer } from '@worldbrain/memex-url-utils'
 import {
     COLLECTION_DEFINITIONS as TAG_COLL_DEFINITIONS,
     COLLECTION_NAMES as TAG_COLL_NAMES,
@@ -237,7 +237,7 @@ export class MetaPickerStorage extends StorageModule {
     async findListsByPage({ url }: { url: string }): Promise<List[]> {
         url = this.options.normalizeUrl(url)
         const entries = await this.findPageListEntriesByPage({ url })
-        const listIds = [...new Set(entries.map(e => e.listId))]
+        const listIds = [...new Set(entries.map((e) => e.listId))]
 
         return this.filterMobileList(
             await this.operation('findListsByIds', { listIds }),
@@ -247,7 +247,7 @@ export class MetaPickerStorage extends StorageModule {
     private filterMobileList = (
         lists: { name: string }[],
     ): { name: string }[] =>
-        lists.filter(list => list.name !== MOBILE_LIST_NAME)
+        lists.filter((list) => list.name !== MOBILE_LIST_NAME)
 
     async findListSuggestions({
         limit = MetaPickerStorage.DEF_SUGGESTION_LIMIT,
@@ -262,7 +262,7 @@ export class MetaPickerStorage extends StorageModule {
             })
 
             return this.filterMobileList(
-                lists.map(list => ({
+                lists.map((list) => ({
                     name: list.name,
                     isChecked: false,
                 })),
@@ -271,14 +271,14 @@ export class MetaPickerStorage extends StorageModule {
 
         const entries = await this.findPageListEntriesByPage({ url })
 
-        const entryListIds = new Set(entries.map(e => e.listId))
+        const entryListIds = new Set(entries.map((e) => e.listId))
 
         const lists: List[] = await this.operation('findListSuggestions', {
             limit,
         })
 
         return this.filterMobileList(
-            lists.map(list => ({
+            lists.map((list) => ({
                 name: list.name,
                 isChecked: entryListIds.has(list.id),
             })),
@@ -296,7 +296,10 @@ export class MetaPickerStorage extends StorageModule {
             limit,
         })
 
-        return tags.map(tag => ({ name: tag.name, isChecked: tag.url === url }))
+        return tags.map((tag) => ({
+            name: tag.name,
+            isChecked: tag.url === url,
+        }))
     }
 
     async suggest(suggestArgs: SuggestArgs): Promise<MetaTypeShape[]> {
@@ -306,7 +309,7 @@ export class MetaPickerStorage extends StorageModule {
         )
 
         return this.filterMobileList(
-            suggested.map(entry => ({ name: entry.name, isChecked: false })),
+            suggested.map((entry) => ({ name: entry.name, isChecked: false })),
         ) as MetaTypeShape[]
     }
 
@@ -329,12 +332,12 @@ export class MetaPickerStorage extends StorageModule {
         // Find any existing tags that are not in input list
         const inputTagsSet = new Set(tags)
         const toRemove = existingTags
-            .map(tag => tag.name)
-            .filter(name => !inputTagsSet.has(name))
+            .map((tag) => tag.name)
+            .filter((name) => !inputTagsSet.has(name))
 
         // Find any input tags that are not existing
-        const existingTagsSet = new Set(existingTags.map(t => t.name))
-        const toAdd = tags.filter(name => !existingTagsSet.has(name))
+        const existingTagsSet = new Set(existingTags.map((t) => t.name))
+        const toAdd = tags.filter((name) => !existingTagsSet.has(name))
 
         for (const name of toAdd) {
             await this.createTag({ name, url })
@@ -351,11 +354,11 @@ export class MetaPickerStorage extends StorageModule {
      */
     async setPageLists({ lists, url }: { lists: string[]; url: string }) {
         const existingLists = await this.findListsByNames({ names: lists })
-        const existingListsSet = new Set(existingLists.map(list => list.name))
+        const existingListsSet = new Set(existingLists.map((list) => list.name))
 
         // Create any missing lists
         const newListIds: number[] = []
-        const missingLists = lists.filter(list => !existingListsSet.has(list))
+        const missingLists = lists.filter((list) => !existingListsSet.has(list))
         for (const name of missingLists) {
             const result = await this.createList({ name })
             newListIds.push(result.object.id)
@@ -366,18 +369,18 @@ export class MetaPickerStorage extends StorageModule {
         // Find any existing entries that are not in input lists
         const inputListIds = [
             ...newListIds,
-            ...existingLists.map(list => list.id),
+            ...existingLists.map((list) => list.id),
         ]
         const inputListIdsSet = new Set(inputListIds)
         const toRemove = existingEntries
-            .map(entry => entry.listId)
-            .filter(id => !inputListIdsSet.has(id))
+            .map((entry) => entry.listId)
+            .filter((id) => !inputListIdsSet.has(id))
 
         // Find any input entries that are not existing
         const existingEntryIdSet = new Set(
-            existingEntries.map(entry => entry.listId),
+            existingEntries.map((entry) => entry.listId),
         )
-        const toAdd = inputListIds.filter(id => !existingEntryIdSet.has(id))
+        const toAdd = inputListIds.filter((id) => !existingEntryIdSet.has(id))
 
         for (const listId of toAdd) {
             await this.createPageListEntry({ listId, pageUrl: url })

--- a/ts/mobile-app/features/meta-picker/storage/index.ts
+++ b/ts/mobile-app/features/meta-picker/storage/index.ts
@@ -21,7 +21,10 @@ export class MetaPickerStorage extends StorageModule {
     static TAG_COLL = TAG_COLL_NAMES.tag
     static LIST_COLL = LIST_COLL_NAMES.list
     static LIST_ENTRY_COLL = LIST_COLL_NAMES.listEntry
+
     static DEF_SUGGESTION_LIMIT = 7
+    static DEF_TAG_LIMIT = 1000
+
     /** This exists to mimic behavior implemented in memex WebExt; Storex auto-PK were not used for whatever reason. */
     static generateListId = () => Date.now()
 
@@ -78,9 +81,7 @@ export class MetaPickerStorage extends StorageModule {
             findTagsByPage: {
                 operation: 'findObjects',
                 collection: MetaPickerStorage.TAG_COLL,
-                args: {
-                    url: '$url:string',
-                },
+                args: [{ url: '$url:string' }, { limit: '$limit:int' }],
             },
             findTagsByName: {
                 operation: 'findObjects',
@@ -206,9 +207,15 @@ export class MetaPickerStorage extends StorageModule {
         })
     }
 
-    findTagsByPage({ url }: { url: string }): Promise<Tag[]> {
+    findTagsByPage({
+        url,
+        limit = MetaPickerStorage.DEF_TAG_LIMIT,
+    }: {
+        url: string
+        limit?: number
+    }): Promise<Tag[]> {
         url = this.options.normalizeUrl(url)
-        return this.operation('findTagsByPage', { url })
+        return this.operation('findTagsByPage', { url, limit })
     }
 
     findTagsByAnnotation({ url }: { url: string }): Promise<Tag[]> {

--- a/ts/mobile-app/features/overview/storage/index.ts
+++ b/ts/mobile-app/features/overview/storage/index.ts
@@ -78,6 +78,16 @@ export class OverviewStorage extends StorageModule {
                         url: '$url:string',
                     },
                 },
+                updatePageTitle: {
+                    operation: 'updateObject',
+                    collection: OverviewStorage.PAGE_COLL,
+                    args: [
+                        { url: '$url:string' },
+                        {
+                            fullTitle: '$title:string',
+                        },
+                    ],
+                },
                 findBookmark: {
                     operation: 'findObject',
                     collection: OverviewStorage.BOOKMARK_COLL,
@@ -185,6 +195,14 @@ export class OverviewStorage extends StorageModule {
         await this.operation('unstarPage', { url })
         await this.operation('deletePage', { url })
         await this.operation('deleteListEntriesForPage', { url })
+    }
+
+    async updatePageTitle({
+        url,
+        title,
+    }: { title: string } & PageOpArgs): Promise<void> {
+        url = this.normalizeUrl(url)
+        await this.operation('updatePageTitle', { url, title })
     }
 
     starPage({ url, time = Date.now() }: PageOpArgs & { time?: number }) {

--- a/ts/mobile-app/features/overview/storage/index.ts
+++ b/ts/mobile-app/features/overview/storage/index.ts
@@ -3,8 +3,7 @@ import {
     StorageModuleConfig,
     StorageModuleConstructorArgs,
 } from '@worldbrain/storex-pattern-modules'
-import { URLPartsExtractor } from '@worldbrain/memex-url-utils/lib/extract-parts/types'
-import { URLNormalizer } from '@worldbrain/memex-url-utils/lib/normalize/types'
+import { URLNormalizer, URLPartsExtractor } from '@worldbrain/memex-url-utils'
 
 import {
     COLLECTION_DEFINITIONS,

--- a/ts/mobile-app/features/page-editor/storage/index.ts
+++ b/ts/mobile-app/features/page-editor/storage/index.ts
@@ -11,6 +11,10 @@ import {
 } from '../../../../annotations/constants'
 import { Note } from '../types'
 
+type RequiredBy<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>
+
+type NoteCreate = Omit<Note, 'url'>
+
 export interface NoteOpArgs {
     url: string
 }
@@ -95,6 +99,13 @@ export class PageEditorStorage extends StorageModule {
                         url: '$url:string',
                     },
                 },
+                deleteNotesForPage: {
+                    operation: 'deleteObjects',
+                    collection: PageEditorStorage.NOTE_COLL,
+                    args: {
+                        pageUrl: '$url:string',
+                    },
+                },
                 deleteNoteFromList: {
                     operation: 'deleteObject',
                     collection: PageEditorStorage.LIST_ENTRY_COLL,
@@ -139,29 +150,51 @@ export class PageEditorStorage extends StorageModule {
         }
     }
 
-    private createAnnotationUrl({
-        pageUrl,
-        timestamp = Date.now(),
-    }: {
+    private createAnnotationUrl = (args: {
         pageUrl: string
-        timestamp?: number
-    }) {
-        return `${this.normalizeUrl(pageUrl)}/#${timestamp}`
-    }
+        timestamp: number
+    }) => `${args.pageUrl}/#${args.timestamp}`
 
-    createNote(note: Omit<Note, 'url'>, customTimestamp = Date.now()) {
-        const created = new Date()
+    createNote(
+        note: RequiredBy<NoteCreate, 'comment'>,
+        customTimestamp = Date.now(),
+    ) {
+        const pageUrl = this.normalizeUrl(note.pageUrl)
 
         return this.operation('createNote', {
-            createdWhen: created,
-            lastEdited: created,
+            createdWhen: new Date(customTimestamp),
+            lastEdited: new Date(customTimestamp),
             ...note,
-            pageUrl: this.normalizeUrl(note.pageUrl),
+            pageUrl,
             url: this.createAnnotationUrl({
-                pageUrl: note.pageUrl,
+                pageUrl,
                 timestamp: customTimestamp,
             }),
         })
+    }
+
+    async createAnnotation(
+        annotation: RequiredBy<NoteCreate, 'selector' | 'body'>,
+        customTimestamp = Date.now(),
+    ) {
+        const pageUrl = this.normalizeUrl(annotation.pageUrl)
+
+        return this.operation('createNote', {
+            createdWhen: new Date(customTimestamp),
+            lastEdited: new Date(customTimestamp),
+            ...annotation,
+            pageUrl,
+            url: this.createAnnotationUrl({
+                pageUrl,
+                timestamp: customTimestamp,
+            }),
+        })
+    }
+
+    async deleteNotesForPage({ url }: { url: string }) {
+        const pageUrl = this.normalizeUrl(url)
+
+        return this.operation('deleteNotesForPage', { url: pageUrl })
     }
 
     async updateNoteText(args: {
@@ -198,6 +231,16 @@ export class PageEditorStorage extends StorageModule {
         }
 
         return notes
+    }
+
+    async findAnnotations({
+        url,
+    }: NoteOpArgs): Promise<RequiredBy<Note, 'body' | 'selector'>[]> {
+        const notes = await this.findNotes({ url })
+
+        return notes.filter(
+            note => note.body?.length && note.selector != null,
+        ) as any
     }
 
     starNote({

--- a/ts/mobile-app/features/page-editor/storage/index.ts
+++ b/ts/mobile-app/features/page-editor/storage/index.ts
@@ -3,7 +3,7 @@ import {
     StorageModuleConfig,
     StorageModuleConstructorArgs,
 } from '@worldbrain/storex-pattern-modules'
-import { URLNormalizer } from '@worldbrain/memex-url-utils/lib/normalize/types'
+import { URLNormalizer } from '@worldbrain/memex-url-utils'
 
 import {
     COLLECTION_DEFINITIONS,
@@ -239,7 +239,7 @@ export class PageEditorStorage extends StorageModule {
         const notes = await this.findNotes({ url })
 
         return notes.filter(
-            note => note.body?.length && note.selector != null,
+            (note) => note.body?.length && note.selector != null,
         ) as any
     }
 

--- a/ts/reader/constants.ts
+++ b/ts/reader/constants.ts
@@ -1,24 +1,23 @@
 import { StorageModuleCollections } from '@worldbrain/storex-pattern-modules'
 
 export const COLLECTION_NAMES = {
-    readable: 'readable',
+    readablePage: 'readablePageArchives',
 }
 
 export const COLLECTION_DEFINITIONS: StorageModuleCollections = {
-    [COLLECTION_NAMES.readable]: {
+    [COLLECTION_NAMES.readablePage]: {
         version: new Date('2020-05-12'),
         fields: {
             url: { type: 'string' },
             fullUrl: { type: 'text' },
             title: { type: 'text' },
-            content: { type: 'text', optional: true },
-            length: { type: 'int', optional: true },
+            excerpt: { type: 'text', optional: true },
+            byline: { type: 'text', optional: true },
+            dir: { type: 'string' },
+            content: { type: 'text' },
+            length: { type: 'int' },
             strategy: { type: 'string' },
         },
-        indices: [
-            { field: 'url', pk: true },
-            { field: 'fullUrl' },
-            { field: 'title' },
-        ],
+        indices: [{ field: 'url', pk: true }],
     },
 }

--- a/ts/reader/constants.ts
+++ b/ts/reader/constants.ts
@@ -9,6 +9,7 @@ export const COLLECTION_DEFINITIONS: StorageModuleCollections = {
         version: new Date('2020-05-12'),
         fields: {
             url: { type: 'string' },
+            title: { type: 'text' },
             excerpt: { type: 'text', optional: true },
             byline: { type: 'text', optional: true },
             dir: { type: 'string' },

--- a/ts/reader/constants.ts
+++ b/ts/reader/constants.ts
@@ -17,7 +17,13 @@ export const COLLECTION_DEFINITIONS: StorageModuleCollections = {
             content: { type: 'text' },
             length: { type: 'int' },
             strategy: { type: 'string' },
+            createdWhen: { type: 'datetime' },
+            lastEdited: { type: 'datetime' },
         },
-        indices: [{ field: 'url', pk: true }],
+        indices: [
+            { field: 'url', pk: true },
+            { field: 'createdWhen' },
+            { field: 'lastEdited' },
+        ],
     },
 }

--- a/ts/reader/constants.ts
+++ b/ts/reader/constants.ts
@@ -9,8 +9,6 @@ export const COLLECTION_DEFINITIONS: StorageModuleCollections = {
         version: new Date('2020-05-12'),
         fields: {
             url: { type: 'string' },
-            fullUrl: { type: 'text' },
-            title: { type: 'text' },
             excerpt: { type: 'text', optional: true },
             byline: { type: 'text', optional: true },
             dir: { type: 'string' },

--- a/ts/reader/constants.ts
+++ b/ts/reader/constants.ts
@@ -1,0 +1,24 @@
+import { StorageModuleCollections } from '@worldbrain/storex-pattern-modules'
+
+export const COLLECTION_NAMES = {
+    readable: 'readable',
+}
+
+export const COLLECTION_DEFINITIONS: StorageModuleCollections = {
+    [COLLECTION_NAMES.readable]: {
+        version: new Date('2020-05-12'),
+        fields: {
+            url: { type: 'string' },
+            fullUrl: { type: 'text' },
+            title: { type: 'text' },
+            content: { type: 'text', optional: true },
+            length: { type: 'int', optional: true },
+            strategy: { type: 'string' },
+        },
+        indices: [
+            { field: 'url', pk: true },
+            { field: 'fullUrl' },
+            { field: 'title' },
+        ],
+    },
+}


### PR DESCRIPTION
Related to:
- Memex ext reader work: https://github.com/WorldBrain/Memex/pull/1028
- Memex Go reader work: https://github.com/WorldBrain/Memex-Mobile/pull/29

I have just pulled your collection definition over from `feature/reader` @cdharris and made some small changes which I'll list below. The intention of bringing this over to this repo is to share the same collection definition between Memex Go and ext. Feel free to bring up any of these points for further discussion:
1. `title` type changed from `string` to `text`:
    - `title` was declared an indexed field, although if `string` fields are indexed IIRC you are limited to queries matching the entire string
    - `text` fields afford full-text search, i.e., querying on individual terms within the title
2. `length` type changed from `string` to `int` + field made optional
    - from what I understand `length` from the Readability Article shape is the *number* of `content` bytes
    - if `content` field is optional, so should this be

@cdharris @ShishKabab  This a good place to discuss this data shape some more. Some quick questions I want to bring up:
1. Related to change point 1 above: What cases do we need the title to be indexed?
2. What cases would we save a "readable" without `content`?
3. Going by https://github.com/mozilla/readability#usage-on-the-web the Readability Article shape contains a few more data attributes that we're choosing not to store.  Namely `excerpt` (article description, or short excerpt from the content), `byline` (author metadata), `dir` (content direction - 'rtl' | 'ltr'). Are we 100% we won't need any of this data in the future? I can see potential uses for all, but far outside of our current scope for the reader.
4. The name of this collection is currently "readable". Personally that feels a bit lacking in description: "a collection of readables". Maybe I'm overthinking it, but do you think it makes sense to call this "readablePage" as to push the mental connection between this collection and our existing "pages" collection? 
5. Continuing from 4, do we want also want to make it plural considering all our other storex collections are named with their plural?